### PR TITLE
feat: configurable ledger prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ const PluginXrpEscrow = require('ilp-plugin-xrp-escrow')
 
 const plugin = new PluginXrpEscrow({
   secret: '<your hot wallet secret>',
-  server: 'wss://s1.ripple.com'
+  server: 'wss://s1.ripple.com',
+  prefix: 'g.crypto.ripple.escrow.' // optional
 })
 ```
 


### PR DESCRIPTION
For the testnet-of-testnets (see https://gitter.im/interledger/Lobby for more info), I'm using `test.crypto.xrp.` as the prefix instead of `g.crypto.ripple.escrow.`. I can't think of a way to make it auto-detect which `.`'s are part of the ledger and which ones are part of `localAddress`. This is the easy fix, a nicer fix may be to use an ILP address format where the `localAddress` does not contain any `.`'s?