### PR TITLE
Fix: make noteToSelf optional

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -146,7 +146,7 @@ module.exports = class PluginXrpEscrow extends EventEmitter2 {
     const dropAmount = (new BigNumber(transfer.amount)).shift(-6)
 
     // TODO: is there a better way to do note to self?
-    this._notesToSelf[transfer.id] = JSON.parse(JSON.stringify(transfer.noteToSelf))
+    this._notesToSelf[transfer.id] = JSON.parse(JSON.stringify(transfer.noteToSelf || {}))
 
     debug('sending', dropAmount.toString(), 'to', localAddress,
       'condition', transfer.executionCondition)


### PR DESCRIPTION
an unspecified noteToSelf previously would cause `SyntaxError: unexpected token u in JSON at position 0`